### PR TITLE
adds missing $self to read_regions call

### DIFF
--- a/scripts/run-bt-mpileup
+++ b/scripts/run-bt-mpileup
@@ -508,7 +508,7 @@ sub init_chunks
     }
     else
     {
-        $regions = read_regions($$self{regions});
+        $regions = $self->read_regions($$self{regions});
     }
 
     my @chunks;


### PR DESCRIPTION
fixes an issue wherein if giving a regions file (rather than an array of regions) to run-bt-mpileup, it would fail with a warning about calling throw on a string. 
