### PR TITLE
Checks to make sure output directory exists

### DIFF
--- a/scripts/run-bt-mpileup
+++ b/scripts/run-bt-mpileup
@@ -194,6 +194,7 @@ sub main
             $chrs{$chr} = 1;
             if ( $self->is_finished("$outdir/$group/$chr.bcf") ) { next; }
             if ( $self->is_finished("$outdir/$group.bcf") ) { next; }
+            if ( ! -d "$outdir/$group/$chr" ) { $self->cmd("mkdir -p '$outdir/$group/$chr'"); }
             $self->spawn('call_variants',"$outdir/$group/$chr/$chr:$from-$to.bcf",$$groups{$group},$chunk);
         }
     }


### PR DESCRIPTION
If not, the output directory is created before spawning call_variants.

I'm not sure where the directories are supposed to be created, but they are failing to be created for me when chromosome names contain '*' and a filename glob match of one chromosome would match that of one previously created. I suspect there is an error somewhere to do with failing to quote a call to `mkdir -p '$outdir'` but I haven't found where it is. 

In any case, this fix should be a good sanity check. 
