### PR TITLE
Fix for pids < 10000 

### DIFF
--- a/modules/RunnerMPM.pm
+++ b/modules/RunnerMPM.pm
@@ -327,7 +327,7 @@ sub _read_jobs
     my %running = ();
     for my $cmd (@running)
     {
-        if ( !($cmd=~/^(\d+)\s+(.*)$/) ) { next; }
+        if ( !($cmd=~/^\s*(\d+)\s+(.*)\s*$/) ) { next; }
         $running{$1} = $2;
     }
     my $script_name = $0;


### PR DESCRIPTION
When process IDs in the `ps --no-headers -o pid,command -e` output have fewer than 5 digits, `ps` on my machine pads them with initial spaces so that the first column lines up right-justified. 

This causes RunnerMPM to fail to recognize that the jobs it has launched are already running and so it launches them again and again (i.e. on my machine with 40 cores and `+loop 5` it launches 40 jobs then 5s later another 40 jobs and so on and so on seemingly forever. 

This probably wasn't a problem in testing because on most machines user processes are often >= 10000, but in my case I'm running in a docker container where the pid of the runner process is sometimes as low as 2, and in that situation without this fix, runner is basically a fork-bomb (although it probably would stop after pids reach 10000).
