### PR TITLE
hash

### DIFF
--- a/modules/Runner/Chunk.pm
+++ b/modules/Runner/Chunk.pm
@@ -105,7 +105,7 @@ sub list_chrs
     my %reg2chr = ();
     if ( exists($args{regions}) )
     {
-        for my $reg (keys %{$args{regions}})
+        for my $reg (sort keys %{$args{regions}})
         {
             if ( $reg=~/^([^:]+):/ ) { $reg2chr{$reg} = $1; }
         }
@@ -148,7 +148,7 @@ sub list_chrs
         }
         if ( exists($args{regions}) )
         {
-            for my $reg (keys %{$args{regions}})
+            for my $reg (sort keys %{$args{regions}})
             {
                 my $chr = exists($reg2chr{$reg}) ? $reg2chr{$reg} : $reg;
                 if ( !exists($chrs{$chr}) ) { next; }

--- a/modules/RunnerLSF.pm
+++ b/modules/RunnerLSF.pm
@@ -215,12 +215,12 @@ sub init_jobs
     if ( scalar keys %zombi_warning )
     {
         my %arrays = ();
-        for my $lsf_id (keys %zombi_warning)
+        for my $lsf_id (sort keys %zombi_warning)
         {
             if ( $lsf_id =~ s/^(\d+)\[(\d+)\]$// ) { push @{$arrays{$1}},$2; }
         }
         my @id_strings = ();
-        for my $id (keys %arrays)
+        for my $id (sort keys %arrays)
         {
             while ( @{$arrays{$id}} )
             {

--- a/modules/RunnerMPM.pm
+++ b/modules/RunnerMPM.pm
@@ -296,17 +296,17 @@ sub _write_jobs
     my ($self,$job_name,$jobs) = @_;
     my $jids_file = "$job_name.jid";
     open(my $fh,'>',$jids_file) or $self->throw("$jids_file: $!\n");
-    for my $id (keys %{$$jobs{Running}})
+    for my $id (sort keys %{$$jobs{Running}})
     {
         my $job = $$jobs{Running}{$id};
         print $fh "$id\t$$job{pid}\t$$job{nfailures}\t$$job{cmd}\n";
     }
-    for my $id (keys %{$$jobs{Error}})
+    for my $id (sort keys %{$$jobs{Error}})
     {
         my $job = $$jobs{Error}{$id};
         print $fh "$id\t-1\t$$job{nfailures}\t$$job{cmd}\n";
     }
-    for my $id (keys %{$$jobs{Done}})
+    for my $id (sort keys %{$$jobs{Done}})
     {
         my $job = $$jobs{Done}{$id};
         print $fh "$id\t0\t$$job{nfailures}\t$$job{cmd}\n";

--- a/modules/RunnerSLURM.pm
+++ b/modules/RunnerSLURM.pm
@@ -473,19 +473,19 @@ sub _write_jobs
     my @unlink = ();
     my $jids_file = "$job_name.jid";
     open(my $fh,'>',$jids_file) or $self->throw("$jids_file: $!\n");
-    for my $id (keys %{$$jobs{Running}})
+    for my $id (sort keys %{$$jobs{Running}})
     {
         my $job = $$jobs{Running}{$id};
         print $fh "$id\t$$job{array_id}\t$$job{nfailures}\t$$job{memlimit}\t$$job{runtime}\n";
         if ( exists($$job{unlink}) ) { push @unlink,$$job{unlink}; }
     }
-    for my $id (keys %{$$jobs{Error}})
+    for my $id (sort keys %{$$jobs{Error}})
     {
         my $job = $$jobs{Error}{$id};
         print $fh "$id\t-1\t$$job{nfailures}\t$$job{memlimit}\t$$job{runtime}\n";
         if ( exists($$job{unlink}) ) { push @unlink,$$job{unlink}; }
     }
-    for my $id (keys %{$$jobs{Done}})
+    for my $id (sort keys %{$$jobs{Done}})
     {
         my $job = $$jobs{Done}{$id};
         print $fh "$id\t0\t$$job{nfailures}\t$$job{memlimit}\t$$job{runtime}\n";

--- a/scripts/run-10x-fastq
+++ b/scripts/run-10x-fastq
@@ -89,7 +89,7 @@ sub main
     #   + out1  => path/to/new/reads1.fastq.gz
     #   + out2  => path/to/new/reads2.fastq.gz
     #   + stats => path/to/new/stats.txt
-    for my $pair (keys %$files)
+    for my $pair (sort keys %$files)
     {
         $$files{$pair}{out1}  = "$$self{outdir}/out/$pair.1.fastq.gz";
         $$files{$pair}{out2}  = "$$self{outdir}/out/$pair.2.fastq.gz";
@@ -108,7 +108,7 @@ sub create_list
 {
     my ($self,$list,$files) = @_;
     open(my $fh,'>',$list) or $self->throw("$list: $!");
-    for my $pair (keys %$files)
+    for my $pair (sort keys %$files)
     {
         print $fh "$$files{$pair}{out1},$$files{$pair}{out2}\t-\t\@RG\\tID:$$files{$pair}{name}\\tSM:$$self{sample}\n";
     }

--- a/scripts/run-beagle
+++ b/scripts/run-beagle
@@ -248,7 +248,7 @@ sub mrProper
     my $chunks = $self->read_chunks();
     my %chroms = ();
     for my $chunk (@$chunks) { $chroms{$$chunk[0]} = 1; }
-    for my $chr (keys %chroms)
+    for my $chr (sort keys %chroms)
     {
         $self->cmd("rm -rf $outdir/$chr");
     }

--- a/scripts/run-bt-mpileup
+++ b/scripts/run-bt-mpileup
@@ -165,7 +165,7 @@ sub main
 
     $self->set_limits(%{$$self{limits}}) unless !exists($$self{limits});
     my %chrs = ();
-    for my $group (keys %$groups)
+    for my $group (sort keys %$groups)
     {
         for my $chunk (@$chunks)
         {
@@ -184,7 +184,7 @@ sub main
 
     # Concatenate chunks and apply filtering
     my @vcfs = ();
-    for my $group (keys %$groups)
+    for my $group (sort keys %$groups)
     {
         if ( $$self{merge_chroms} )
         {
@@ -193,7 +193,7 @@ sub main
         }
         else
         {
-            for my $chr (keys %chrs)
+            for my $chr (sort keys %chrs)
             {
                 push @vcfs, "$outdir/$group/$chr.bcf";
                 $self->spawn('merge_chunks',"$outdir/$group/$chr.bcf",$$groups{$group},$chunks,$chr);
@@ -209,16 +209,16 @@ sub main
         if ( $$self{merge_chroms} )
         {
             my @merge = ();
-            for my $group (keys %$groups) { push @merge, "$outdir/$group.bcf"; }
+            for my $group (sort keys %$groups) { push @merge, "$outdir/$group.bcf"; }
             $self->spawn('merge_vcfs',"$outdir/merged/all.bcf",\@merge);
             push @vcfs,@merge;
         }
         else
         {
-            for my $chr (keys %chrs)
+            for my $chr (sort keys %chrs)
             {
                 my @merge = ();
-                for my $group (keys %$groups) { push @merge, "$outdir/$group/$chr.bcf"; }
+                for my $group (sort keys %$groups) { push @merge, "$outdir/$group/$chr.bcf"; }
                 $self->spawn('merge_vcfs',"$outdir/merged/$chr.bcf",\@merge);
                 push @vcfs,@merge;
             }
@@ -242,7 +242,7 @@ sub main
 sub mrProper
 {
     my ($self,$outdir) = @_;
-    for my $pop (keys %{$$self{pops}})
+    for my $pop (sort keys %{$$self{pops}})
     {
         $self->cmd("rm -rf $outdir/$pop");
     }
@@ -257,7 +257,7 @@ sub clean
     my $groups = $self->init_groups();
     my $chunks = $self->init_chunks();
     my %chrs = ();
-    for my $group (keys %$groups)
+    for my $group (sort keys %$groups)
     {
         for my $chunk (@$chunks)
         {
@@ -271,7 +271,7 @@ sub clean
                 unlink($file) unless !-e $file;
             }
         }
-        for my $chr (keys %chrs)
+        for my $chr (sort keys %chrs)
         {
             rmdir("$outdir/$group/$chr");
             unlink("$outdir/$group/$chr.list") unless (!-e "$outdir/$group/$chr.list");
@@ -346,7 +346,7 @@ sub init_groups
             chomp($items[-1]);
             my $grp  = exists($cols{grp}) ? $items[$cols{grp}] : 'all';
             my $smpl = {};
-            for my $col (keys %cols) { $$smpl{$col} = $items[$cols{$col}]; }
+            for my $col (sort keys %cols) { $$smpl{$col} = $items[$cols{$col}]; }
             push @{$$groups{$grp}{list}}, $smpl;
         }
         close($fh) or $self->throw("close failed: $$self{alns}{fname}");
@@ -372,7 +372,7 @@ sub init_groups
             close($fh) or $self->throw("close failed: $$self{alns}");
         }
     }
-    for my $group (keys %$groups)
+    for my $group (sort keys %$groups)
     {
         $$groups{$group}{name} = $group;
         $self->write_group($$self{outdir},$$groups{$group});
@@ -478,7 +478,7 @@ return;
     }
     close($fh);
 
-    for my $pl (keys %pl)
+    for my $pl (sort keys %pl)
     {
         if ( !exists($bam_pls{$pl}) ) { $self->throw("The platform \"$pl\" not present in any of the BAMs.\n"); }
     }
@@ -652,7 +652,7 @@ sub debug_commands
     my ($self) = @_;
     my ($chr,$pos) = split(/:/, $$self{debug});
     my $groups = $self->init_groups();
-    my $group  = (keys %$groups)[0];
+    my $group  = (sort keys %$groups)[0];
     my $alns   = $$groups{$group}{alns};
 
     my $cmd = 

--- a/scripts/run-commands
+++ b/scripts/run-commands
@@ -127,7 +127,7 @@ sub create_io_map
 {
     my ($self,$files) = @_;
     if ( !defined $$self{io_map} ) { return; }
-    for my $map (keys %{$$self{io_map}})
+    for my $map (sort keys %{$$self{io_map}})
     {
         my $map_name = $self->expand_vars($map,%$self);
         open(my $fh,'>',$map_name) or $self->throw("$map_name: $!");

--- a/scripts/run-eagle
+++ b/scripts/run-eagle
@@ -134,7 +134,7 @@ sub main
     my %merge = ();
     for my $chunk (@$samples)
     {
-        for my $chr (keys %$chrs)
+        for my $chr (sort keys %$chrs)
         {
             my $src_file = $$chunk{src_file};
             if ( !exists($$chrs{$chr}{$src_file}) ) { next; }
@@ -156,9 +156,9 @@ sub main
     my @dst_files = ();
     if ( $$self{merge_samples} )
     {
-        for my $src_file (keys %merge)
+        for my $src_file (sort keys %merge)
         {
-            for my $chr (keys %{$merge{$src_file}})
+            for my $chr (sort keys %{$merge{$src_file}})
             {
                 push @dst_files, { src_file=>$src_file, region=>$chr, vcf=>$merge{$src_file}{$chr}, fmt=>$$self{fmt} };
             }
@@ -181,7 +181,7 @@ sub main
                 push @{$tasks{$src}{list}}, "$$file{dst_dir}/$$file{dst_file}.$fmt";
             }
             my @concat = ();
-            for my $src (keys %tasks) 
+            for my $src (sort keys %tasks) 
             { 
                 push @concat, { list=>$tasks{$src}{list}, src_file=>$src, region=>'all', fmt=>$$self{fmt} }; 
             }
@@ -195,9 +195,9 @@ sub main
     }
     else
     {
-        for my $src_file (keys %merge)
+        for my $src_file (sort keys %merge)
         {
-            for my $chr (keys %{$merge{$src_file}})
+            for my $chr (sort keys %{$merge{$src_file}})
             {
                 for my $file (@{$merge{$src_file}{$chr}})
                 {

--- a/scripts/run-eagle-wg
+++ b/scripts/run-eagle-wg
@@ -148,7 +148,7 @@ sub mrProper
     my $chunks = $self->read_chunks();
     my %chroms = ();
     for my $chunk (@$chunks) { $chroms{$$chunk[0]} = 1; }
-    for my $chr (keys %chroms)
+    for my $chr (sort keys %chroms)
     {
         $self->cmd("rm -rf $outdir/$chr");
     }

--- a/scripts/run-gtcheck-lanelets
+++ b/scripts/run-gtcheck-lanelets
@@ -153,7 +153,7 @@ sub bam2groups
             $$smpl{$1} = 1;
         }
         if ( scalar keys %$smpl > 1 ) { $self->throw("Expected one sample in $bam, found more: ".join(',',keys %$smpl)); }
-        print $fh "$bam\t".(keys %$smpl)[0]."\n";
+        print $fh "$bam\t".(sort keys %$smpl)[0]."\n";
     }
     close($fh) or $self->throw("close failed: $outfile.part");
     rename("$outfile.part",$outfile) or $self->throw("rename $outfile.part $outfile: $!");

--- a/scripts/run-gvcf-calling
+++ b/scripts/run-gvcf-calling
@@ -146,7 +146,7 @@ sub main
     }
     else
     {
-        for my $chr (keys %chrs)
+        for my $chr (sort keys %chrs)
         {
             push @vcfs, "$outdir/$chr.bcf";
             $self->spawn('merge_chunks',"$outdir/$chr.bcf",$chunks,$chr);
@@ -169,7 +169,7 @@ sub main
 sub mrProper
 {
     my ($self,$outdir) = @_;
-    for my $pop (keys %{$$self{pops}})
+    for my $pop (sort keys %{$$self{pops}})
     {
         $self->cmd("rm -rf $outdir/$pop");
     }

--- a/scripts/run-impute2
+++ b/scripts/run-impute2
@@ -299,7 +299,7 @@ sub set_chunk_options
     my ($self,$chr,$from,$to) = @_;
     if ( !exists($$self{chunk_options}) ) { return; }
     my $hit;
-    for my $chunk (keys %{$$self{chunk_options}})
+    for my $chunk (sort keys %{$$self{chunk_options}})
     {
         if ( !($chunk=~/^([^:]+):(\d+)-(\d+)$/) ) { $self->throw("Could not parse the chunk_options: [$chunk]"); }
         if ( $chr ne $1 ) { next; }

--- a/scripts/run-mapdamage
+++ b/scripts/run-mapdamage
@@ -111,7 +111,7 @@ sub create_io_map
 {
     my ($self,$files) = @_;
     if ( !defined $$self{io_map} ) { return; }
-    for my $map (keys %{$$self{io_map}})
+    for my $map (sort keys %{$$self{io_map}})
     {
         my $map_name = $self->expand_vars($map,%$self);
         open(my $fh,'>',$map_name) or $self->throw("$map_name: $!");

--- a/scripts/run-pbwt-reference-impute
+++ b/scripts/run-pbwt-reference-impute
@@ -303,7 +303,7 @@ sub get_regions
         close($fh) || $self->throw("$$self{outdir}/lists/regions.list: $!");
     }
 
-    $self->throw("No regions found") unless (keys %regions);
+    $self->throw("No regions found") unless (sort keys %regions);
 
     return \%regions;
 }
@@ -352,7 +352,7 @@ sub mrProper
     my $chunks = $self->read_chunks();
     my %chroms = ();
     for my $chunk (@$chunks) { $chroms{$$chunk[0]} = 1; }
-    for my $chr (keys %chroms)
+    for my $chr (sort keys %chroms)
     {
         $self->cmd("rm -rf $outdir/$chr");
     }

--- a/scripts/run-qc-bam
+++ b/scripts/run-qc-bam
@@ -238,7 +238,7 @@ sub check_md5
     my $bam_md5 = $self->parse_header_md5($fh);
     close($fh) or $self->throw("close failed: $$self{samtools} view -H $bam");
 
-    for my $chr (keys %$bam_md5)
+    for my $chr (sort keys %$bam_md5)
     {
         if ( !exists($$ref_md5{$chr}) ) { next; }   # cannot check
         if ( $$ref_md5{$chr} ne $$bam_md5{$chr} ) { $self->throw("MD5 mismatch for $chr:\n\t$$ref_md5{$chr}\t$ref_hdr\n\t$$bam_md5{$chr}\t$bam\n"); }

--- a/scripts/run-runners
+++ b/scripts/run-runners
@@ -662,7 +662,7 @@ sub clean_project
     debug_msg($opts,"Cleaning project: $name\n");
     $$project{prefix} = "$$opts{dropbox_tmp}/$$project{run_id}/$name";
 
-    for my $dst (keys %{$$project{outputs}})
+    for my $dst (sort keys %{$$project{outputs}})
     {
         # Create a subdirectory '$dst' and move all listed files in there:
         #   dst => [ 'src1','src2' ]
@@ -868,7 +868,7 @@ sub parse_step
     # set step-specific keys ("pbwt/key: value") and keys shared by all steps ("*/key: value")
     my %reserved = map { $_ => 1 } (qw(include run));
     my %predef = ( prefix=>$$project{prefix} );
-    for my $var (keys %$setup)
+    for my $var (sort keys %$setup)
     {
         my ($name,$key) = split(m{/},$var);
         if ( $name eq '*' or $name eq $step_name )
@@ -877,14 +877,14 @@ sub parse_step
             if ( !exists($predef{$key}) && defined $$setup{$var} ) { $predef{$key} = $$setup{$var}; }
         }
     }
-    for my $var (keys %{$$chain{$step_name}})
+    for my $var (sort keys %{$$chain{$step_name}})
     {
         if ( $reserved{$var} or exists($predef{$var}) or !defined $$chain{$step_name}{$var} ) { next; }
         $predef{$var} = expand_vars(\%predef,$$chain{$step_name}{$var});
     }
 
     # expand 
-    for my $key (keys %$step)
+    for my $key (sort keys %$step)
     {
         my $value = $$step{$key};
         if ( !defined $value ) { next; }    # allow undef as override
@@ -898,7 +898,7 @@ sub parse_step
         # override defaults in step's runner config. Originally, only keys
         # from the step.config would be written, but that was inconvenient.
         # Now we include all predefeined keys in the config.
-        for my $key (keys %predef)
+        for my $key (sort keys %predef)
         {
             if ( $reserved{$key} ) { next; } # reserved keys: include,run
             $$step{config}{$key} = parse_config_value($predef{$key});

--- a/scripts/run-shapeit
+++ b/scripts/run-shapeit
@@ -219,7 +219,7 @@ sub mrProper
     my $chunks = $self->read_chunks();
     my %chroms = ();
     for my $chunk (@$chunks) { $chroms{$$chunk[0]} = 1; }
-    for my $chr (keys %chroms)
+    for my $chr (sort keys %chroms)
     {
         $self->cmd("rm -rf $outdir/$chr");
     }
@@ -239,7 +239,7 @@ sub set_chunk_options
     my ($self,$chr,$from,$to) = @_;
     if ( !exists($$self{chunk_options}) ) { return; }
     my $hit;
-    for my $chunk (keys %{$$self{chunk_options}})
+    for my $chunk (sort keys %{$$self{chunk_options}})
     {
         if ( !($chunk=~/^([^:]+):(\d+)-(\d+)$/) ) { $self->throw("Could not parse the chunk_options: [$chunk]"); }
         if ( $chr ne $1 ) { next; }

--- a/scripts/run-st-mpileup
+++ b/scripts/run-st-mpileup
@@ -262,7 +262,7 @@ sub main
 
     # Call the variants
 	# $self->write_annot_file();    not calling vcf-annotate by default any more
-    for my $pop (keys %{$$self{pops}})
+    for my $pop (sort keys %{$$self{pops}})
     {
         for my $chunk (@$chunks)
         {
@@ -287,7 +287,7 @@ sub main
             my $from = $$chunk{from};
             my $to   = $$chunk{to};
             my @vcfs = ();
-            for my $pop (keys %{$$self{pops}})
+            for my $pop (sort keys %{$$self{pops}})
             {
                 if ( $pop eq 'pooled' ) { next; }
                 push @vcfs, "$outdir/$pop/$chr/$chr:$from-$to.vcf.gz";
@@ -303,7 +303,7 @@ sub main
 
 	# Merge the files and apply hard filtering. Two branches for whole-genome or per-chromosome files
 	my @vcfs;
-	for my $pop (keys %{$$self{pops}})
+	for my $pop (sort keys %{$$self{pops}})
 	{
 		if ( $$self{merge_chroms} ) 
 		{ 
@@ -345,7 +345,7 @@ sub main
 sub mrProper
 {
     my ($self,$outdir) = @_;
-    for my $pop (keys %{$$self{pops}})
+    for my $pop (sort keys %{$$self{pops}})
     {
         $self->cmd("rm -rf $outdir/$pop");
     }
@@ -357,7 +357,7 @@ sub clean
     my ($self,$outdir) = @_;
     $self->SUPER::clean($outdir);
     my $chunks = $self->get_chunks;
-    for my $pop (keys %{$$self{pops}})
+    for my $pop (sort keys %{$$self{pops}})
     {
         for my $chunk (@$chunks)
         {
@@ -426,7 +426,7 @@ sub check_sanity
     }
     close($fh);
 
-    for my $pl (keys %pl)
+    for my $pl (sort keys %pl)
     {
         if ( !exists($bam_pls{$pl}) ) { $self->throw("The platform \"$pl\" not present in any of the BAMs.\n"); }
     }
@@ -610,7 +610,7 @@ sub sample_list
     close($in);
 
     open(my $out,'>',"$outfile.part") or $self->throw("$outfile.part: $!");
-    if ( !defined $sexes ) { $sexes = $self->get_sample_sex(keys %samples); }
+    if ( !defined $sexes ) { $sexes = $self->get_sample_sex(sort keys %samples); }
     for my $sample (sort keys %samples)
     {
         print $out "$sample\t$$sexes{$sample}\n";
@@ -674,14 +674,14 @@ sub read_fai
     my ($self,$fai,$regexs) = @_;
 
     my %chunk_opts = ();
-    for my $key (keys %{$$self{chunk_options}})
+    for my $key (sort keys %{$$self{chunk_options}})
     {
         my ($chr,$fromto) = split(/:/,$key);
         if ( !defined $fromto or $fromto eq '' ) { next; }
         my ($from,$to) = split(/-/,$fromto);
         push @{$chunk_opts{$chr}},[$from,$to];
     }
-    for my $chr (keys %{$$self{ploidy}})
+    for my $chr (sort keys %{$$self{ploidy}})
     {
         if ( ref($$self{ploidy}{$chr}) ne 'ARRAY' ) { next; }
         for my $reg (@{$$self{ploidy}{$chr}})
@@ -690,7 +690,7 @@ sub read_fai
             push @{$chunk_opts{$chr}},[$from,$to];
         }
     }
-    for my $chr (keys %chunk_opts)
+    for my $chr (sort keys %chunk_opts)
     {
         $chunk_opts{$chr} = [ sort { $$a[0]<=>$$b[0] } @{$chunk_opts{$chr}} ];
     }
@@ -768,7 +768,7 @@ sub set_chunk_options
     my ($self,$chr,$from,$to) = @_;
     if ( !exists($$self{chunk_options}) ) { return; }
     my $hit;
-    for my $chunk (keys %{$$self{chunk_options}})
+    for my $chunk (sort keys %{$$self{chunk_options}})
     {
         if ( !($chunk=~/^([^:]+):(\d+)-(\d+)$/) && !($chunk=~/^([^:]+)$/) ) { $self->throw("Could not parse chunk_options: [$chunk]"); }
         if ( $chr ne $1 ) { next; }

--- a/scripts/run-test-complex
+++ b/scripts/run-test-complex
@@ -65,7 +65,7 @@ sub main
     # that each group can proceed independently of the others.
 
     $self->set_limits(memory=>500);     # Just to show how to decrease the limits again
-    for my $group (keys %$done)
+    for my $group (sort keys %$done)
     {
         $self->spawn('group',"$ENV{HOME}/Hello.$group",$$done{$group});
     }


### PR DESCRIPTION
Order of spawned job matters
Some perl versions iterate hash keys in undefined order which
leads to assignment of incorrect ids in Runner/Chunk.pm splitting
pipelines.